### PR TITLE
fix single representation

### DIFF
--- a/alphafold/model/model.py
+++ b/alphafold/model/model.py
@@ -167,6 +167,11 @@ class RunModel:
       return result, prev
 
 
+    if return_representations:
+      single_act = self._params['alphafold/alphafold_iteration/evoformer/single_activations']
+      single_act = jax.tree_map(lambda x:np.asarray(x, dtype=np.float16), single_act)          
+
+
     # initialize random key
     key = jax.random.PRNGKey(random_seed)
     
@@ -185,9 +190,9 @@ class RunModel:
         result, prev = run(sub_key, sub_feat, prev)
         
         if return_representations:
-
+          single = prev["prev_msa_first_row"]
           result["representations"] = {"pair":   prev["prev_pair"],
-                                       "single": prev["prev_msa_first_row"]}
+                                       "single": single @ single_act["weights"] + single_act["bias"]}
                                        
         # callback
         if callback is not None: callback(result, r)

--- a/alphafold/model/model.py
+++ b/alphafold/model/model.py
@@ -122,6 +122,7 @@ class RunModel:
               feat: features.FeatureDict,
               random_seed: int = 0,
               return_representations: bool = False,
+              fix_single_representation: bool = True,
               callback: Any = None) -> Mapping[str, Any]:
     """Makes a prediction by inferencing the model on the provided features.
 
@@ -167,10 +168,9 @@ class RunModel:
       return result, prev
 
 
-    if return_representations:
+    if return_representations and fix_single_representation:
       single_act = self._params['alphafold/alphafold_iteration/evoformer/single_activations']
-      single_act = jax.tree_map(lambda x:np.asarray(x, dtype=np.float16), single_act)          
-
+      single_act = jax.tree_map(lambda x:np.asarray(x, dtype=np.float16), single_act)
 
     # initialize random key
     key = jax.random.PRNGKey(random_seed)
@@ -191,8 +191,10 @@ class RunModel:
         
         if return_representations:
           single = prev["prev_msa_first_row"]
+          if fix_single_representation:
+            single = single @ single_act["weights"] + single_act["bias"]
           result["representations"] = {"pair":   prev["prev_pair"],
-                                       "single": single @ single_act["weights"] + single_act["bias"]}
+                                       "single": single}
                                        
         # callback
         if callback is not None: callback(result, r)


### PR DESCRIPTION
msa_activation is (N,L,256)
in colabfold v1.5.2 we return msa_activation[0] as our single representation vector
looks like there is one extra linear layer to convert msa_activations[0] to single_activation:
![image](https://github.com/sokrypton/alphafold/assets/4187522/1183a0fb-1a07-4626-9ada-12e32fd6891c)
If anything the (L,256) representation might be better, as you might be losing some information by doing the extra transformation at the end. 

But since people are asking, I'm adding the transformation back so that the output is (L,386).

