### PR TITLE
Add chain ipTM

### DIFF
--- a/alphafold/model/modules_multimer.py
+++ b/alphafold/model/modules_multimer.py
@@ -461,12 +461,18 @@ class AlphaFold(hk.Module):
     if not return_representations:
       del ret['representations']
 
+    # Extract chain NUM # MODIFIED
+    chain_num = c.embeddings_and_evoformer.max_relative_chain + 1 # MODIFIED
+
     # add confidence metrics
+
     ret.update(confidence.get_confidence_metrics(
       prediction_result=ret,
       mask=batch["seq_mask"],
       rank_by=self.config.rank_by,
-      use_jnp=True))
+      use_jnp=True,
+      chain_num=chain_num # MODIFIED
+      ))
 
     ret["tol"] = confidence.compute_tol(
       prev["prev_pos"], 


### PR DESCRIPTION
Hello,

I struggled to extract the `chain_num` from `asym_id` tracer, that seemed trivial, but with the `jax` library (first experience for me), it was impossible for me.
So I add to extract it from `c.embeddings_and_evoformer.max_relative_chain`.

`chain_iptm` and the whole `ptm_matrix` are added to the `confidence_metric` dictionnary.

Concerning the whole  `ptm_matrix` I think it should be saved as the pae matrix, to later be treated and for example extract the interface iptm as in [af2complex](https://github.com/FreshAirTonight/af2complex/blob/main/src/alphafold/common/confidence.py).

I will also do a pull request on colabfold to save the chain_iptm and ptm_matrix is the json output. 

Cheers,
Samuel